### PR TITLE
Create update-on-release action to automatically update PBH for pl course repos that depend on it

### DIFF
--- a/.github/workflows/on-release.yml
+++ b/.github/workflows/on-release.yml
@@ -38,7 +38,9 @@ jobs:
           cache: 'pip'
       - name: Update pbh version in serverFilesCourse
         run: |
-          rm -rf serverFilesCourse/problem_bank_* # cleanup/remove old versions
+          rm -rf serverFilesCourse/problem_bank_helpers serverFilesCourse/problem_bank_helpers-*.dist-info
+          rm -rf serverFilesCourse/sigfig serverFilesCourse/sigfig-*.dist-info
+          rm -rf serverFilesCourse/sortedcontainers sortedcontainers-*.dist-info
           pip install problem_bank_helpers sigfig sortedcontainers --upgrade --no-deps --target serverFilesCourse
       - name: Commit and push updated serverFilesCourse
         run: |

--- a/.github/workflows/on-release.yml
+++ b/.github/workflows/on-release.yml
@@ -36,14 +36,14 @@ jobs:
           python-version: '3.10'
           # saves pip cache between runs, in case a run is ever finished before some runs are started and it can be reused somehow
           cache: 'pip'
-      - name: Update PBS version in serverFilesCourse
+      - name: Update pbh version in serverFilesCourse
         run: |
           rm -rf serverFilesCourse/problem_bank_* # cleanup/remove old versions
-          pip install --upgrade problem_bank_helpers --target serverFilesCourse
+          pip install problem_bank_helpers sigfig sortedcontainers --upgrade --no-deps --target serverFilesCourse
       - name: Commit and push updated serverFilesCourse
         run: |
           git config --global user.name 'fmoosvi'
           git config --global user.email 'firas.moosvi@ubc.ca'
           git add serverFilesCourse
-          git commit -am "Update problem_bank_scripts to ${{ needs.get-version.outputs.ver }}"
+          git commit -am "Automatic GH Action to update problem_bank_helpers to ${{ needs.get-version.outputs.ver }}"
           git push

--- a/.github/workflows/on-release.yml
+++ b/.github/workflows/on-release.yml
@@ -1,0 +1,49 @@
+name: Push Updated Problem Bank Scripts to Dependent Repos
+
+on: 
+  release:
+    types: [published]
+
+jobs:
+  get-version:
+    runs-on: ubuntu-latest
+    env:
+      TAG_NAME: ${{ github.event.release.tag_name }}
+    outputs:
+        ver: ${{ steps.version_name.outputs.version }}
+    steps:
+      - name: Strip leading 'v' from tag and return as output
+        id: version_name
+        run: echo "version=$(echo ${TAG_NAME/#v/})" >> $GITHUB_OUTPUT
+  push-to-dependents:
+    needs: get-version
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false # if one repo fails, continue with the others, it might be unrelated
+      matrix:
+        repo: [PrairieLearnUBC/pl-ubc-opb000, PrairieLearnUBC/pl-ubc-opb100] # add more repos here
+        # if the token needs to be different per repo, add a token matrix using the extend matrix syntax
+        # as shown here: https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#example-expanding-configurations
+    steps:
+      - name: Checkout ${{ matrix.repo }}
+        uses: actions/checkout@v3 
+        with: # checks out default branch
+          repository: ${{ matrix.repo }}
+          token: ${{ secrets.PAT_GITHUB_PRAIRIELEARN }}
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+          # saves pip cache between runs, in case a run is ever finished before some runs are started and it can be reused somehow
+          cache: 'pip'
+      - name: Update PBS version in serverFilesCourse
+        run: |
+          rm -rf serverFilesCourse/problem_bank_* # cleanup/remove old versions
+          pip install --upgrade problem_bank_helpers --target serverFilesCourse
+      - name: Commit and push updated serverFilesCourse
+        run: |
+          git config --global user.name 'fmoosvi'
+          git config --global user.email 'firas.moosvi@ubc.ca'
+          git add serverFilesCourse
+          git commit -am "Update problem_bank_scripts to ${{ needs.get-version.outputs.ver }}"
+          git push


### PR DESCRIPTION
- This workflow first parses the version number from the published release (removing leading "v"s)
- It then uses a matrix to update specified dependent prairielearn courses in parallel
- The action uses a secret to specify the PAT for pulling and pushing to the dependent repo(s)

Resolves open-resources/problem_bank_scripts#57 

Superceeds open-resources/problem_bank_scripts#62