### PR TITLE
Fix test warnings

### DIFF
--- a/src/problem_bank_helpers/problem_bank_helpers.py
+++ b/src/problem_bank_helpers/problem_bank_helpers.py
@@ -192,7 +192,7 @@ def roundp(*args,**kwargs):
     else:
         num_str = num_str + str(0)*z*2
     
-    # Add trailing zeroes if necessary (WIP)
+    # Add trailing zeroes if necessary
     if z > sigfigs(num_str):
         split_string = num_str.split("e")
         if "." not in split_string[0]:
@@ -200,6 +200,7 @@ def roundp(*args,**kwargs):
         split_string[0] = split_string[0] + ("0"*(z - sigfigs(num_str)))
         num_str = "e".join(split_string)
     
+    # sigfig.round doesn't like zero
     if abs(float(num_str)) == 0:
         result = num_str
         print("num is zero: " + result + "\n")

--- a/src/problem_bank_helpers/problem_bank_helpers.py
+++ b/src/problem_bank_helpers/problem_bank_helpers.py
@@ -193,14 +193,18 @@ def roundp(*args,**kwargs):
         num_str = num_str + str(0)*z*2
     
     # Add trailing zeroes if necessary (WIP)
-    #if z > sigfigs(num_str):
-    #    split_string = num_str.split("e")
-    #    if "." not in split_string[0]:
-    #        split_string[0] = split_string[0] + "."
-    #    split_string[0] = split_string[0] + ("0"*(z - sigfigs(num_str)))
-    #    num_str = "e".join(split_string)
-                
-    result = sigfig.round(num_str,**kwargs)
+    if z > sigfigs(num_str):
+        split_string = num_str.split("e")
+        if "." not in split_string[0]:
+            split_string[0] = split_string[0] + "."
+        split_string[0] = split_string[0] + ("0"*(z - sigfigs(num_str)))
+        num_str = "e".join(split_string)
+    
+    if abs(float(num_str)) == 0:
+        result = num_str
+        print("num is zero: " + result + "\n")
+    else:            
+        result = sigfig.round(num_str,**kwargs)
         
     # Switch back to the original format if it was a float
     if isinstance(a[0],float):

--- a/src/problem_bank_helpers/problem_bank_helpers.py
+++ b/src/problem_bank_helpers/problem_bank_helpers.py
@@ -83,7 +83,7 @@ def round_sig(x, sig):
     else:
         y = sig - int(floor(log10(abs(x)))) - 1
     # avoid precision loss with floats 
-    x = Decimal(repr(x))
+    x = Decimal(str(x))
     return float(round(x, y))
 
 # def round_sig(x, sig_figs = 3):
@@ -169,8 +169,7 @@ def roundp(*args,**kwargs):
         
     num_str = str(float(a[0]))
         
-    # Add trailing zeroes if needed
-    
+    # Create default sigfigs if necessary
     if kw.get('sigfigs',None):
         z = kw['sigfigs']
     elif kw.get('decimals', None):
@@ -178,8 +177,7 @@ def roundp(*args,**kwargs):
     else:
         z = 3 # Default sig figs
         kwargs['sigfigs'] = z
-
-    
+    # Add trailing zeroes if necessary
 
     # Handle big and small numbers carefully
     if abs(float(num_str)) < 1e-4 or abs(float(num_str)) > 1e15:
@@ -208,7 +206,7 @@ def round_str(*args,**kwargs):
     if type(args[0]) is str:
         return args[0]
     
-    if 'sigfigs' not in kwargs.keys():
+    if 'sigfigs' not in kwargs.keys() and 'decimals' not in kwargs.keys():
         kwargs['sigfigs'] = 2
     
     if 'format' not in kwargs.keys():
@@ -248,7 +246,7 @@ def num_as_str(num, digits_after_decimal = 2):
         round_context = getcontext()
         round_context.rounding = ROUND_HALF_UP
 
-        tmp = Decimal(repr(num)).quantize(Decimal('1.'+'0'*digits_after_decimal))
+        tmp = Decimal(str(num)).quantize(Decimal('1.'+'0'*digits_after_decimal))
         
         return str(tmp)
 

--- a/src/problem_bank_helpers/problem_bank_helpers.py
+++ b/src/problem_bank_helpers/problem_bank_helpers.py
@@ -10,6 +10,10 @@ import importlib.resources
 from decimal import Decimal, getcontext, ROUND_HALF_UP
 import re
 
+# Set rounding context
+round_context = getcontext()
+round_context.rounding = ROUND_HALF_UP
+
 ## Load data and dictionaries
 
 ## Better way of loading data and dictionaries
@@ -177,7 +181,6 @@ def roundp(*args,**kwargs):
     else:
         z = 3 # Default sig figs
         kwargs['sigfigs'] = z
-    # Add trailing zeroes if necessary
 
     # Handle big and small numbers carefully
     if abs(float(num_str)) < 1e-4 or abs(float(num_str)) > 1e15:
@@ -188,6 +191,14 @@ def roundp(*args,**kwargs):
         kwargs['notation'] = 'sci'
     else:
         num_str = num_str + str(0)*z*2
+    
+    # Add trailing zeroes if necessary (WIP)
+    #if z > sigfigs(num_str):
+    #    split_string = num_str.split("e")
+    #    if "." not in split_string[0]:
+    #        split_string[0] = split_string[0] + "."
+    #    split_string[0] = split_string[0] + ("0"*(z - sigfigs(num_str)))
+    #    num_str = "e".join(split_string)
                 
     result = sigfig.round(num_str,**kwargs)
         
@@ -241,11 +252,6 @@ def num_as_str(num, digits_after_decimal = 2):
     elif type(num) == dict:
         return num
     else:
-        
-
-        round_context = getcontext()
-        round_context.rounding = ROUND_HALF_UP
-
         tmp = Decimal(str(num)).quantize(Decimal('1.'+'0'*digits_after_decimal))
         
         return str(tmp)

--- a/tests/test_problem_bank_helpers.py
+++ b/tests/test_problem_bank_helpers.py
@@ -1,4 +1,0 @@
-from src.problem_bank_helpers import __version__
-
-def test_version():
-    assert __version__ == '0.1.14'

--- a/tests/test_problem_bank_helpers_other_functionality.py
+++ b/tests/test_problem_bank_helpers_other_functionality.py
@@ -1,7 +1,9 @@
 from src.problem_bank_helpers import __version__
 import pandas as pd
 import pytest
+import tempfile
 import pathlib
+import os
 
 def test_version():
     assert __version__ == '0.1.14'
@@ -43,15 +45,20 @@ def test_load_csv(file_path):
 
 
 def test_empty_csv():
-    # ensure loading an empty csv fails
-    file_path = "data/empty.csv"
+    try:
+        # Create a temporary empty CSV file
+        with tempfile.NamedTemporaryFile(suffix=".csv", delete=False) as csvfile:
+            pass
 
-    # Create an empty CSV file
-    with open(file_path, 'w') as csvfile:
-        pass
+        # Call the test_load_csv function with the temporary empty CSV file
+        with pytest.raises(pd.errors.EmptyDataError):
+            test_load_csv(csvfile.name)
 
-    with pytest.raises(pd.errors.EmptyDataError):
-        test_load_csv(file_path)
+    finally:
+        # Clean up the temporary file after the test
+        if csvfile:
+            csvfile.close()
+            os.remove(csvfile.name)
 
 
 @pytest.mark.parametrize("file_path", files)

--- a/tests/test_problem_bank_helpers_rounding.py
+++ b/tests/test_problem_bank_helpers_rounding.py
@@ -296,7 +296,7 @@ def test_roundstr_with_sigfig_std_notation():
 
 def test_roundstr_with_decimal_sci_notation_dp():
     """Test rounding an integer with specified decimals and notation='sci'"""
-    assert pbh.round_str(98767, decimals=2, notation='sci') == 99000
+    assert pbh.round_str(98767.1234, decimals=2, notation='sci') == 98767.12
 
 @pytest.mark.parametrize('id, input, sigfigs, expected_result', [
     ('id_positive float',3.14159, 3, 3.14),  # Test rounding a positive float to 3 sigfigs


### PR DESCRIPTION
This addresses comments from pr #14 .
- removes the three warnings from the previous CI testing (fixes decimal and sigfig conflicts in `pbh.roundstr`, and handles 0 cases for `pbh.roundp`)
- changes `repr` to `str`
- rounding context is set at the start of the file instead of halfway through a function
- ~~TODO: CSV validation testing~~ , empty.csv has been removed, and a tempfile is now used instead.