### PR TITLE
Fix `round_sig()` typing regression

### DIFF
--- a/src/problem_bank_helpers/problem_bank_helpers.py
+++ b/src/problem_bank_helpers/problem_bank_helpers.py
@@ -79,8 +79,17 @@ def sigfigs(x):
     return sigfigs('e'.join(n))
     
     
-# A function to rounding a number x keeping sig significant figures. 
 def round_sig(x, sig):
+    """
+    Round a number to a specified number of significant digits.
+
+    Args:
+        x (float or int): The number to be rounded.
+        sig (int): The number of significant digits.
+
+    Returns:
+        float or int: The rounded number retaining the type of the input.
+    """
     from math import log10, floor
     if x == 0:
         y = 0
@@ -89,7 +98,7 @@ def round_sig(x, sig):
     # avoid precision loss with floats 
     decimal_x = round( Decimal(str(x)) , y )
     
-    return float(decimal_x) if isinstance(x, float) else int(decimal_x)
+    return int(decimal_x) if isinstance(x, int) else float(decimal_x)
 
 
 # def round_sig(x, sig_figs = 3):

--- a/src/problem_bank_helpers/problem_bank_helpers.py
+++ b/src/problem_bank_helpers/problem_bank_helpers.py
@@ -87,8 +87,10 @@ def round_sig(x, sig):
     else:
         y = sig - int(floor(log10(abs(x)))) - 1
     # avoid precision loss with floats 
-    x = Decimal(str(x))
-    return float(round(x, y))
+    decimal_x = round( Decimal(str(x)) , y )
+    
+    return float(decimal_x) if isinstance(x, float) else int(decimal_x)
+
 
 # def round_sig(x, sig_figs = 3):
 #     """A function that rounds to specific significant digits. Original from SO: https://stackoverflow.com/a/3413529/2217577; adapted by Jake Bobowski

--- a/src/problem_bank_helpers/problem_bank_helpers.py
+++ b/src/problem_bank_helpers/problem_bank_helpers.py
@@ -98,7 +98,7 @@ def round_sig(x, sig):
     # avoid precision loss with floats 
     decimal_x = round( Decimal(str(x)) , y )
     
-    return int(decimal_x) if isinstance(x, int) else float(decimal_x)
+    return type(x)(decimal_x)
 
 
 # def round_sig(x, sig_figs = 3):

--- a/tests/test_problem_bank_helpers_rounding.py
+++ b/tests/test_problem_bank_helpers_rounding.py
@@ -179,9 +179,6 @@ def test_roundsig_rigorous(id, input, sigfigs, expected_result):
 
 
 #test num_as_str function
-def test_num_as_str_rigorous(id, input, digits_after_decimal, expected_result):
-    assert pbh.num_as_str(input, digits_after_decimal) == expected_result
-
 def test_num_as_str_default_dp():
     """test default decimal places"""
     assert pbh.num_as_str(3.14159) == '3.14'
@@ -214,6 +211,8 @@ def test_num_as_str_invalid_args_kwargs():
     ],
     ids=idfn
 )
+def test_num_as_str_rigorous(id, input, digits_after_decimal, expected_result):
+    assert pbh.num_as_str(input, digits_after_decimal) == expected_result
 
 
 # Test roundp function

--- a/tests/test_problem_bank_helpers_rounding.py
+++ b/tests/test_problem_bank_helpers_rounding.py
@@ -133,12 +133,20 @@ def test_sigfigs(test_group, variables):
             pytest.fail(f"test group is not defined (got: '{test_group}')")
         assert (pbh.sigfigs(test_input) == correct_sigfigs), f"input: {test_input}, output: {pbh.sigfigs(test_input)}"
 
-def test_sigfigs_floatinput_fail():
+def test_sigfigs_float_input_fail():
     with pytest.raises(Exception):
         pbh.sigfigs(float(1))
 
 
 # Test round_sig function
+def test_roundsig_int_returns_int():
+    """Test rounding an int with specified sigfigs"""
+    assert type(pbh.roundp(123, 2)) is int
+    
+def test_roundsig_with_float():
+    """Test rounding an int with specified sigfigs"""
+    assert type(pbh.roundp(123.0, 2)) is float
+
 @pytest.mark.parametrize('id, input, sigfigs, expected_result', [
     ('id_positive float',3.14159, 3, 3.14),  # Test rounding a positive float to 3 sigfigs
     ('id_negative float',-2.71828, 3, -2.72),  # Test rounding a negative float to 3 sigfigs

--- a/tests/test_problem_bank_helpers_rounding.py
+++ b/tests/test_problem_bank_helpers_rounding.py
@@ -141,11 +141,16 @@ def test_sigfigs_float_input_fail():
 # Test round_sig function
 def test_roundsig_int_returns_int():
     """Test rounding an int with specified sigfigs"""
-    assert type(pbh.roundp(123, 2)) is int
+    assert type(pbh.round_sig(123, 2)) is int
     
 def test_roundsig_with_float():
-    """Test rounding an int with specified sigfigs"""
-    assert type(pbh.roundp(123.0, 2)) is float
+    """Test rounding an float with specified sigfigs"""
+    assert type(pbh.round_sig(123.0, 2)) is float
+
+def test_roundsig_with_string_fail():
+    """Test rounding a string with specified sigfigs"""
+    with pytest.raises(Exception):
+        pbh.round_sig("123.0", 2)
 
 @pytest.mark.parametrize('id, input, sigfigs, expected_result', [
     ('id_positive float',3.14159, 3, 3.14),  # Test rounding a positive float to 3 sigfigs
@@ -169,11 +174,25 @@ def test_roundsig_with_float():
     ],
     ids=idfn
 )
-def test_roundsig(id, input, sigfigs, expected_result):
+def test_roundsig_rigorous(id, input, sigfigs, expected_result):
     assert (pbh.round_sig(input, sigfigs) == expected_result)
 
 
 #test num_as_str function
+def test_num_as_str_rigorous(id, input, digits_after_decimal, expected_result):
+    assert pbh.num_as_str(input, digits_after_decimal) == expected_result
+
+def test_num_as_str_default_dp():
+    """test default decimal places"""
+    assert pbh.num_as_str(3.14159) == '3.14'
+
+def test_num_as_str_invalid_args_kwargs():
+    with pytest.raises(TypeError):
+        pbh.num_as_str(123.45, 2, "args")  # Function should not accept *args
+
+    with pytest.raises(TypeError):
+        pbh.num_as_str(123.45, 2, digits_after_decimal=2)  # Function should not accept **kwargs
+
 @pytest.mark.parametrize('id, input, digits_after_decimal, expected_result', [
     ('id_positive float',3.14159, 2, '3.14'),  # Test rounding a positive float to 2 digits after decimal
     ('id_negative float',-2.71828, 2, '-2.72'),  # Test rounding a negative float to 2 digits after decimal
@@ -195,19 +214,6 @@ def test_roundsig(id, input, sigfigs, expected_result):
     ],
     ids=idfn
 )
-def test_num_as_str(id, input, digits_after_decimal, expected_result):
-    assert pbh.num_as_str(input, digits_after_decimal) == expected_result
-
-def test_num_as_str_default_dp():
-    """test default decimal places"""
-    assert pbh.num_as_str(3.14159) == '3.14'
-
-def test_num_as_str_invalid_args_kwargs():
-    with pytest.raises(TypeError):
-        pbh.num_as_str(123.45, 2, "args")  # Function should not accept *args
-
-    with pytest.raises(TypeError):
-        pbh.num_as_str(123.45, 2, digits_after_decimal=2)  # Function should not accept **kwargs
 
 
 # Test roundp function
@@ -277,7 +283,7 @@ def test_roundp_notation_sci_dp():
     ],
     ids=idfn
 )
-def test_roundp_rigorous_sigfig(id, input, sigfigs, expected_result):
+def test_roundp_rigorous(id, input, sigfigs, expected_result):
     assert pbh.roundp(input, sigfigs=sigfigs) == expected_result
 
 
@@ -328,5 +334,5 @@ def test_roundstr_with_decimal_sci_notation_dp():
     ],
     ids=idfn
 )
-def test_roundstr_rigorous_sigfig(id, input, sigfigs, expected_result):
+def test_roundstr_rigorous(id, input, sigfigs, expected_result):
     assert pbh.round_str(input, sigfigs=sigfigs) == expected_result

--- a/tests/test_problem_bank_helpers_rounding.py
+++ b/tests/test_problem_bank_helpers_rounding.py
@@ -141,11 +141,11 @@ def test_sigfigs_float_input_fail():
 # Test round_sig function
 def test_roundsig_int_returns_int():
     """Test rounding an int with specified sigfigs"""
-    assert type(pbh.round_sig(123, 2)) is int
+    assert isinstance(pbh.round_sig(123, 2), int)
     
 def test_roundsig_with_float():
     """Test rounding an float with specified sigfigs"""
-    assert type(pbh.round_sig(123.0, 2)) is float
+    assert isinstance(pbh.round_sig(123.0, 2), float)
 
 def test_roundsig_with_string_fail():
     """Test rounding a string with specified sigfigs"""


### PR DESCRIPTION
This PR:
- ensures numbers passed to `round_sig()` retain typing: closes #21
- adds tests to check typing of outputs of `round_sig()`: `float`, `int`, will return `float`, and `int` respectively. Checks`str` inputs will raise an exception.
- adds a docstring for `round_sig()`.
- reorders rigorous function tests to be after basic function tests.