### PR TITLE
Remove dependency caching from on-release.yml

### DIFF
--- a/.github/workflows/on-release.yml
+++ b/.github/workflows/on-release.yml
@@ -34,8 +34,6 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: '3.10'
-          # saves pip cache between runs, in case a run is ever finished before some runs are started and it can be reused somehow
-          cache: 'pip'
       - name: Update pbh version in serverFilesCourse
         run: |
           rm -rf serverFilesCourse/problem_bank_helpers serverFilesCourse/problem_bank_helpers-*.dist-info


### PR DESCRIPTION
Because there is no `requirements.txt` or `pyproject.toml` file, `actions/setup-python@v4` cannot cache dependencies

Fixes action run failure here: https://github.com/open-resources/problem_bank_helpers/actions/runs/5803654600