### PR TITLE
Fix the if/elif/else statement so it works correctly

### DIFF
--- a/src/problem_bank_helpers/problem_bank_helpers.py
+++ b/src/problem_bank_helpers/problem_bank_helpers.py
@@ -185,9 +185,9 @@ def roundp(*args,**kwargs):
     num_str = str(float(a[0]))
 
     # Create default sigfigs if necessary
-    if kw.get('sigfigs',None):
+    if kw.get('sigfigs',None) != None:
         z = kw['sigfigs']
-    elif kw.get('decimals', None):
+    elif kw.get('decimals', None) != None:
         z = kw['decimals']
     else:
         z = 3 # Default sig figs


### PR DESCRIPTION
if `decimals` was set to `0`, sigfigs are also set to `3` which results in a warning:

```
/Users/firasm/.pyenv/versions/3.10.2/lib/python3.10/site-packages/sigfig/sigfig.py:390: UserWarning: Cannot round by both sigfigs & decimals, ignoring decimal constraint
  warn('Cannot round by both sigfigs & decimals, ignoring decimal constraint')
```