### PR TITLE
Automated/Trusted publishing for problem bank helpers

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,197 @@
+# Based on
+# https://github.com/python/typing_extensions/blob/main/.github/workflows/publish.yml and
+# https://packaging.python.org/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/
+
+name: Test builds and publish Python distribution to PyPI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  release:
+    types: [published]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build dist
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+      - name: Install Poetry
+        run: pipx install poetry
+      - name: Build release
+        run: poetry build
+      - name: Upload the distribution packages
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+  test-wheel:
+    name: Test wheel
+    runs-on: ubuntu-latest
+    needs: [build]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+          cache: pip
+      - name: Download release dists
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+      - name: Install wheel
+        run: |
+          export path_to_file=$(find dist -type f -name "problem_bank_helpers-*.whl")
+          echo "::notice::Installing wheel: $path_to_file"
+          python -m pip install --user $path_to_file
+          python -m pip list
+      - name: Install test dependencies
+        run: python -m pip install --user pytest
+      - name: Run tests against installed wheel
+        run: rm -rf src/ && pytest tests/
+
+  test-sdist:
+    name: Test sdist
+    runs-on: ubuntu-latest
+    needs: [build]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+          cache: pip
+      - name: Download release dists
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+      - name: Install sdist
+        run: |
+          export path_to_file=$(find dist -type f -name "problem_bank_helpers-*.tar.gz")
+          echo "::notice::Installing sdist: $path_to_file"
+          python -m pip install --user $path_to_file
+          python -m pip list
+      - name: Install test dependencies
+        run: python -m pip install --user pytest
+      - name: Run tests against installed sdist
+        run: rm -rf src/ && pytest tests/
+
+  test-banks:
+    name: Test Problem Banks Build
+    needs: [build]
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false # We want to know all issues, even if one fails
+      matrix:
+        repo: # If more problem banks are ever created, add them here
+          - instructor_physics_bank
+          - instructor_datascience_bank
+          - instructor_stats_bank
+    steps:
+      - name: Checkout ${{ matrix.repo }}
+        uses: actions/checkout@v4
+        with:
+          repository: open-resources/${{ matrix.repo }}
+          token: ${{ secrets.API_TOKEN_GITHUB }}
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+          cache: pip
+      - name: Download release dists
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+      - name: Install Problem Bank Dependencies
+        run: |
+          python -m pip install --upgrade --upgrade-strategy eager -r requirements.txt
+          python -m pip install --upgrade problem_bank_scripts
+      - name: Install built wheel
+        run: |
+          python -m pip uninstall -y problem_bank_helpers
+          export path_to_file=$(find dist -type f -name "problem_bank_helpers-*.whl")
+          echo "::notice::Installing wheel: $path_to_file"
+          python -m pip install --user $path_to_file
+          python -m pip list
+      - name: Test problem bank generates properly
+        run: python scripts/process.py 'source' --instructor=True --public=True --prairielearn=True
+
+  publish:
+    name: Publish new release to PyPI
+    if: github.event_name == 'release' # only publish to PyPI on releases
+    needs:  # Ensure build and tests have passed before publishing
+      - build
+      - test-wheel
+      - test-sdist
+      - test-banks
+    runs-on: ubuntu-latest
+    # Specifying a GitHub environment so manual approval by an approved user to create a release is required
+    # https://docs.github.com/en/actions/deployment/targeting-different-environments/using-environments-for-deployment#deployment-protection-rules
+    environment:
+      name: publish
+      url: https://pypi.org/p/problem-bank-helpers/
+    permissions:
+      # IMPORTANT: this permission is mandatory for trusted publishing
+      # https://docs.pypi.org/trusted-publishers/
+      id-token: write
+    steps:
+      - name: Download release dists
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+      - name: Ensure exactly one sdist and one wheel have been downloaded
+        run: test $(ls dist/*.tar.gz | wc -l) = 1 && test $(ls dist/*.whl | wc -l) = 1
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+  
+  github-release:
+    name: upload dists to GitHub release
+    needs: [publish]
+    permissions:
+      id-token: write
+      attestations: write
+      contents: write
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Download release dists
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+      - name: Attest Build Provenance
+        uses: actions/attest-build-provenance@v1
+        with:
+          subject-path: 'dist/**'
+      - name: Upload Dists to GitHub Release
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          gh release upload
+          '${{ github.ref_name }}' dist/**
+          --repo '${{ github.repository }}'
+    
+  push-to-question-banks:
+    uses: ./.github/workflows/update-dependents.yml
+    needs: [publish]
+    with:
+      version: ${{ github.event.release.tag_name }}

--- a/.github/workflows/update-dependents.yml
+++ b/.github/workflows/update-dependents.yml
@@ -1,23 +1,21 @@
 name: Push Updated Problem Bank Helpers to Dependent Repos
 
 on: 
+  workflow_call:
+    inputs:
+      version:
+        type: string
+        required: true
+        description: 'Version being updated to'
   workflow_dispatch:
-  release:
-    types: [published]
+    inputs:
+      version:
+        type: string
+        required: true
+        description: 'Version being updated to'
 
 jobs:
-  get-version:
-    runs-on: ubuntu-latest
-    env:
-      TAG_NAME: ${{ github.event.release.tag_name }}
-    outputs:
-        ver: ${{ steps.version_name.outputs.version }}
-    steps:
-      - name: Strip leading 'v' from tag and return as output
-        id: version_name
-        run: echo "version=$(echo ${TAG_NAME/#v/})" >> $GITHUB_OUTPUT
-  push-to-dependents:
-    needs: get-version
+  push-to-question-banks:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false # if one repo fails, continue with the others, it might be unrelated
@@ -46,5 +44,5 @@ jobs:
           git config --global user.name 'fmoosvi'
           git config --global user.email 'firas.moosvi@ubc.ca'
           git add serverFilesCourse
-          git commit -am "Automatic GH Action to update problem_bank_helpers to ${{ needs.get-version.outputs.ver }}"
+          git commit -am "Automatic GH Action to update problem_bank_helpers to ${{ github.event.inputs.version }}"
           git push

--- a/bump.sh
+++ b/bump.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+VERSION_LEVEL=$1
+
+if [ -z "$VERSION_LEVEL" ]; then
+    echo "Usage: $0 <VERSION_LEVEL>"
+    echo "  VERSION_LEVEL: The level of the version to bump. One of: patch, minor, major"
+    exit 1
+fi
+
+# Bump the version and save poetry output to string
+ret=$(poetry version $VERSION_LEVEL)
+echo $ret
+FROM=$(echo $ret | awk '{ print $4; }')
+TO=$(echo $ret | awk '{ print $6; }')
+
+# change any references to the old version in the project
+echo "Bumping version from $FROM to $TO in src/problem_bank_helpers/__init__.py"
+sed -i "s/__version__ = \"$FROM\"/__version__ = \"$TO\"/g" src/problem_bank_helpers/__init__.py
+echo "Bumping version from $FROM to $TO in tests/test_problem_bank_helpers.py"
+sed -i "s/__version__ == \"$FROM\"/__version__ == \"$TO\"/g" tests/test_problem_bank_helpers.py
+
+# commit the changes
+git add src/problem_bank_helpers/__init__.py tests/test_problem_bank_helpers.py pyproject.toml
+git commit -m "Increment version from $FROM to $TO"
+
+# create a tag
+git tag -a "v$TO" -m "Version $TO"
+
+echo "Bump to version $TO complete. Remember to run 'git push' and 'git push --tags' to push the changes."

--- a/tests/test_problem_bank_helpers.py
+++ b/tests/test_problem_bank_helpers.py
@@ -1,4 +1,4 @@
-from src.problem_bank_helpers import __version__
+from problem_bank_helpers import __version__
 
 def test_version():
     assert __version__ == '0.2.7'

--- a/tests/test_problem_bank_helpers_other_functionality.py
+++ b/tests/test_problem_bank_helpers_other_functionality.py
@@ -1,21 +1,15 @@
+import importlib.resources
+import os
+import tempfile
+
 import pandas as pd
 import pytest
-import tempfile
-import pathlib
-import os
 
 import problem_bank_helpers as pbh
 
-files = sorted(
-    [
-        file.name
-        for file in pathlib.Path(
-            "src/problem_bank_helpers/data/"
-        ).iterdir()
-    ]
-)
+files = sorted(importlib.resources.files("problem_bank_helpers.data").iterdir())
 
-files = [("src/problem_bank_helpers/data/" + f) for f in files if f != 'empty.csv']
+files = [pytest.param(f, id=f.name) for f in files if f.name != 'empty.csv']
 
 
 @pytest.mark.parametrize("file_path", files)

--- a/tests/test_problem_bank_helpers_other_functionality.py
+++ b/tests/test_problem_bank_helpers_other_functionality.py
@@ -1,10 +1,10 @@
-from src.problem_bank_helpers import __version__
-from src.problem_bank_helpers import problem_bank_helpers as pbh
 import pandas as pd
 import pytest
 import tempfile
 import pathlib
 import os
+
+import problem_bank_helpers as pbh
 
 files = sorted(
     [

--- a/tests/test_problem_bank_helpers_rounding.py
+++ b/tests/test_problem_bank_helpers_rounding.py
@@ -1,6 +1,6 @@
-from src.problem_bank_helpers import __version__
-from src.problem_bank_helpers import problem_bank_helpers as pbh
 import pytest
+
+import problem_bank_helpers as pbh
 
 def idfn(input):
     if str(input)[0:3] == "id_":


### PR DESCRIPTION
Same idea as in open-resources/problem_bank_scripts#98, but for problem_bank_helpers - I anticipate we might need to make a new release at some point this summer, especially if we want to resolve some of the open PRs. Also, the lockfile needs to get updated at some point, we've had a few major versions of some packages (like numpy) released somewhat recently, which we may need to make sure support still works for.